### PR TITLE
Fix logic issue in invoking content-notification async function

### DIFF
--- a/common_util.bal
+++ b/common_util.bal
@@ -1,4 +1,6 @@
 import ballerina/regex;
+import ballerina/random;
+import ballerina/lang.'string as strings;
 
 isolated function generateTopicName(string topic) returns string {
     return nomalizeString(topic);

--- a/hub_service.bal
+++ b/hub_service.bal
@@ -159,7 +159,6 @@ websubhub:Service hubService = service object {
         if (persistingResult is error) {
             log:printError("Error occurred while persisting the subscription ", err = persistingResult.message());
         }
-        error? notificationError = notifySubscriber(hubClientEp, consumerEp, groupName);
     }
 
     # Unsubscribes a consumer from the hub.


### PR DESCRIPTION
## Purpose
> $subject

* Here `notifySubscriber` async function should only be invoked when there is a new subscription. And when the `Hub` is restarted it should start `notifySubscriber` for all the persisted subscribers as well.
* When an `unsubscription` happens we could check whether it is available in `registeredSubscribers` state and cancel the previously invoked async function.